### PR TITLE
Exec plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,15 @@
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <executable>java</executable>
+                    <mainClass>org.bundestagsbot.BundestagsBot</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.4.3</version>

--- a/readme.md
+++ b/readme.md
@@ -25,4 +25,10 @@ cd target
 java -jar bundestagsbot.jar
 ```
 
+or all in one via:
+
+```bash
+mvn install exec:java
+```
+
 or use docker if you are familiar with it.


### PR DESCRIPTION
Um die Anwendung direkt über maven starten zu können. Ist für manche IDEs auch besser integriert als einfach das generierte jar zu starten.