### PR TITLE
added some basic tests for internal objects, regarding #6

### DIFF
--- a/src/test/java/org/bundestagsbot/embeds/ErrorLogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/ErrorLogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ErrorLogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        ErrorLogEmbed errorLogEmbed = new ErrorLogEmbed();
+        MessageEmbed messageEmbed = errorLogEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/embeds/FailureLogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/FailureLogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FailureLogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        FailureLogEmbed failureLogEmbed = new FailureLogEmbed();
+        MessageEmbed messageEmbed = failureLogEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/embeds/LogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/LogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        LogEmbed logEmbed = new LogEmbed();
+        MessageEmbed messageEmbed = logEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/embeds/NeutralLogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/NeutralLogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NeutralLogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        NeutralLogEmbed neutralLogEmbed = new NeutralLogEmbed();
+        MessageEmbed messageEmbed = neutralLogEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/embeds/SuccessLogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/SuccessLogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SuccessLogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        SuccessLogEmbed successLogEmbed = new SuccessLogEmbed();
+        MessageEmbed messageEmbed = successLogEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/embeds/WarningLogEmbedTest.java
+++ b/src/test/java/org/bundestagsbot/embeds/WarningLogEmbedTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.embeds;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WarningLogEmbedTest {
+    @Test
+    public void EmbedBuildTest() {
+        WarningLogEmbed warningLogEmbed = new WarningLogEmbed();
+        MessageEmbed messageEmbed = warningLogEmbed.build();
+        Assert.assertNotNull(messageEmbed);
+    }
+}

--- a/src/test/java/org/bundestagsbot/internals/surveys/SurveyRequesterTest.java
+++ b/src/test/java/org/bundestagsbot/internals/surveys/SurveyRequesterTest.java
@@ -1,0 +1,23 @@
+package org.bundestagsbot.internals.surveys;
+
+import org.bundestagsbot.internals.surveys.dawumjsonmapper.RootDawumJson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class SurveyRequesterTest {
+    @Test
+    public void getAPIResponse() {
+        RootDawumJson response = null;
+        try {
+            response = SurveyRequester.getAPIResponse();
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Receiving response from survey API failed.");
+        }
+        Assert.assertNotNull("Response cannot be null", response);
+    }
+}

--- a/src/test/java/org/bundestagsbot/meta/AboutTest.java
+++ b/src/test/java/org/bundestagsbot/meta/AboutTest.java
@@ -1,0 +1,14 @@
+package org.bundestagsbot.meta;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AboutTest {
+    @Test
+    public void getInfo() {
+        String result = About.getInfo();
+        assertNotNull("About info cannot be null", result);
+        assertFalse("About info cannot be empty", result.isBlank());
+    }
+}

--- a/src/test/java/org/bundestagsbot/meta/VersionInfoTest.java
+++ b/src/test/java/org/bundestagsbot/meta/VersionInfoTest.java
@@ -1,0 +1,21 @@
+package org.bundestagsbot.meta;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionInfoTest {
+    @Test
+    public void getVersion() {
+        String result = VersionInfo.getVersion();
+        assertNotNull("Version info cannot be null", result);
+        assertFalse("Version info cannot be empty", result.isBlank());
+    }
+
+    @Test
+    public void getLongVersion() {
+        String result = VersionInfo.getLongVersion();
+        assertNotNull("Long version info cannot be null", result);
+        assertFalse("Long version info cannot be empty", result.isBlank());
+    }
+}


### PR DESCRIPTION
Hab mal ein paar einfache Unittests erstellt. 
Bei den Embeds teste ich beispielsweise nur das Builden, da die `.build()` Methode schon überprüft, ob Embeds an Discord geschickt werden können oder ob es irgendwelche Fehler gibt (falsche Formate, zu lange Beschreibung, etc.).
Das ist vermutlich auch das relevanteste, da die Embeds ja wirklich überall Verwendung finden.